### PR TITLE
Improve performance

### DIFF
--- a/R/igraph.R
+++ b/R/igraph.R
@@ -170,7 +170,7 @@ graph_as_nested_list <- function(graph) {
 
   # extract vertex attributes once to avoide repeated extraction in
   # graph_as_nested_list_recursive()
-  vertices <- igraph::vertex_attr(taxonomy)
+  vertices <- igraph::vertex_attr(graph)
 
   # do the recursion
   graph_as_nested_list_recursive(

--- a/R/igraph.R
+++ b/R/igraph.R
@@ -172,16 +172,24 @@ graph_as_nested_list <- function(graph) {
   # graph_as_nested_list_recursive()
   vertices <- igraph::vertex_attr(graph)
 
+  # commpute children only once to avoid repeated computation in
+  # graph_as_nested_list_recursive()
+  all_children <- igraph::adjacent_vertices(graph, igraph::V(graph))
+
   # do the recursion
   graph_as_nested_list_recursive(
     graph,
     as.integer(get_root_node(graph)),
-    vertices
+    vertices,
+    all_children
   )
 }
 
 
-graph_as_nested_list_recursive <- function(graph, root, vertices) {
+graph_as_nested_list_recursive <- function(graph,
+                                           root,
+                                           vertices,
+                                           all_children) {
 
   node_list <- list(
     name = vertices$label[root],
@@ -192,14 +200,14 @@ graph_as_nested_list_recursive <- function(graph, root, vertices) {
 
   # if there are children, they must be adde to the list
   # note that using mode with an integer is much faster
-  children <- igraph::neighbors(graph, root, mode = 1)
+  children <- all_children[[root]]
   if (length(children) == 0) return(node_list)
 
   c(node_list,
     list(
       children = unname(
         lapply(children, graph_as_nested_list_recursive,
-               graph = graph, vertices = vertices)
+               graph = graph, vertices = vertices, all_children = all_children)
       )
     )
   )

--- a/R/igraph.R
+++ b/R/igraph.R
@@ -168,19 +168,26 @@ graph_as_nested_list <- function(graph) {
   opt_old <- igraph::igraph_options(return.vs.es = FALSE)
   on.exit(igraph::igraph_options(opt_old))
 
+  # extract vertex attributes once to avoide repeated extraction in
+  # graph_as_nested_list_recursive()
+  vertices <- igraph::vertex_attr(taxonomy)
+
   # do the recursion
-  graph_as_nested_list_recursive(graph, as.integer(get_root_node(graph)))
+  graph_as_nested_list_recursive(
+    graph,
+    as.integer(get_root_node(graph)),
+    vertices
+  )
 }
 
 
-graph_as_nested_list_recursive <- function(graph, root) {
+graph_as_nested_list_recursive <- function(graph, root, vertices) {
 
-  root_attr <- igraph::vertex_attr(graph, index = root)
   node_list <- list(
-    name = root_attr$label,
-    collapsed = root_attr$collapsed,
-    fill = root_attr$colour,
-    tooltip = root_attr$tooltip
+    name = vertices$label[root],
+    collapsed = vertices$collapsed[root],
+    fill = vertices$colour[root],
+    tooltip = vertices$tooltip[root]
   )
 
   # if there are children, they must be adde to the list
@@ -191,7 +198,8 @@ graph_as_nested_list_recursive <- function(graph, root) {
   c(node_list,
     list(
       children = unname(
-        lapply(children, graph_as_nested_list_recursive, graph = graph)
+        lapply(children, graph_as_nested_list_recursive,
+               graph = graph, vertices = vertices)
       )
     )
   )

--- a/R/igraph.R
+++ b/R/igraph.R
@@ -175,6 +175,10 @@ graph_as_nested_list <- function(graph) {
   # commpute children only once to avoid repeated computation in
   # graph_as_nested_list_recursive()
   all_children <- igraph::adjacent_vertices(graph, igraph::V(graph))
+  # if an igraph version with bug is used, we must add one to all vertex indices
+  if (getOption("simpleTaxonomy_has_igraph_bug")) {
+    all_children <- lapply(all_children, `+`, 1)
+  }
 
   # do the recursion
   graph_as_nested_list_recursive(
@@ -211,4 +215,22 @@ graph_as_nested_list_recursive <- function(graph,
       )
     )
   )
+}
+
+
+# some versions of igraph have a bug in adjacent_vertices() that causes vertex
+# indices to be off by one if return.vs.es is FALSE. This function checks,
+# whether this bug is present.
+# Issue: https://github.com/igraph/rigraph/issues/1605
+
+has_igraph_bug <- function() {
+
+  g <- igraph::make_tree(2)
+
+  opt_old <- igraph::igraph_options(return.vs.es = FALSE)
+  on.exit(igraph::igraph_options(opt_old))
+
+  # if the adjacent vertex of 1 is returned as 1, the bug is present
+  igraph::adjacent_vertices(g, 1)[[1]] == 1
+
 }

--- a/R/simpleTaxonomy-package.R
+++ b/R/simpleTaxonomy-package.R
@@ -18,3 +18,10 @@ NULL
   collapsibleTree::collapsibleTree
   NULL
 }
+
+
+.onLoad <- function(lib, pkg) {
+
+  options(simpleTaxonomy_has_igraph_bug = has_igraph_bug())
+
+}


### PR DESCRIPTION
improve the performance of `graph_as_nested_list()` by using vectorised functions where possible and by setting the igraph option return.vs.es to FALSE. Note that a bug in igraph leads to wrong results. The bug is caught and the results are corrected in a way that ensures that the package will also work with a fixed version of igraph.